### PR TITLE
fix: Added missing package to Pipfile

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -10,6 +10,7 @@ flask-restx = "*"
 flask-jwt-extended = "*"
 peewee = "*"
 python-dotenv = "*"
+colorama = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
Heyo! Seems like colorama is missing from the Pipfile ref: 
![image](https://user-images.githubusercontent.com/33762262/171592412-d4746fe6-770b-4877-b00b-4f9177de0318.png)

Took the liberty to add it for you, with this added to the Pipfile everything works as expected 